### PR TITLE
Rewrite the library to use asynchronous functions et. al.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Oren Novotny
+Copyright (c) 2018 Claire Novotny
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Scripts/Sign-Package.ps1
+++ b/Scripts/Sign-Package.ps1
@@ -19,7 +19,7 @@ $nupkgs = gci $Env:ArtifactDirectory\*.nupkg -recurse | Select -ExpandProperty F
 foreach ($nupkg in $nupkgs){
 	Write-Host "Submitting $nupkg for signing"
 
-	.\SignClient 'sign' -c $appSettings -i $nupkg -f $fileList -r $Env:SignClientUser -s $Env:SignClientSecret -n 'SingleInstanceHelper' -d 'SingleInstanceHelper' -u 'https://github.com/onovotny/SingleInstanceHelper' 
+	.\SignClient 'sign' -c $appSettings -i $nupkg -f $fileList -r $Env:SignClientUser -s $Env:SignClientSecret -n 'SingleInstanceHelper' -d 'SingleInstanceHelper' -u 'https://github.com/novotnyllc/SingleInstanceHelper'
 
 	Write-Host "Finished signing $nupkg"
 }

--- a/SingleInstanceHelper.sln
+++ b/SingleInstanceHelper.sln
@@ -9,7 +9,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		azure-pipelines.yml = azure-pipelines.yml
-		Directory.Build.Props = Directory.Build.Props
 		README.md = README.md
 		version.json = version.json
 	EndProjectSection

--- a/SingleInstanceHelper/ApplicationActivator.cs
+++ b/SingleInstanceHelper/ApplicationActivator.cs
@@ -54,7 +54,7 @@ namespace SingleInstanceHelper
                 new Payload {CommandLineArguments = Environment.GetCommandLineArgs().ToList()};
 
             // Send the message
-            await SendOptionsToNamedPipe(un, namedPipeXmlPayload);
+            await SendOptionsToNamedPipe(un, namedPipeXmlPayload).ConfigureAwait(false);
             return false; // Signal to quit
         }
 

--- a/SingleInstanceHelper/ApplicationActivator.cs
+++ b/SingleInstanceHelper/ApplicationActivator.cs
@@ -29,15 +29,15 @@ namespace SingleInstanceHelper
         /// When not the first instance, the command line args will be passed to the first one.
         /// </summary>
         /// <param name="otherInstanceCallback">Callback to execute on the first instance with command line args
-        /// from subsequent launches. If specified, it will run on the current synchronization context.</param>
+        /// from subsequent launches. It will run on the current synchronization context.</param>
         /// <param name="uniqueName">A unique identifier of the app running. Calling this method from
         /// many different apps with the same <paramref name="uniqueName"/> specified will return
         /// <see langword="true"/> only on one of them</param>
-        /// <returns>Whether this is the first instance of the application that
-        /// called this method.</returns>
+        /// <returns>Whether this is the first instance of the application that called this method.</returns>
         public static async Task<bool> LaunchOrReturnAsync(
-            Action<IReadOnlyList<string>>? otherInstanceCallback = null, string? uniqueName = null)
+            Action<IReadOnlyList<string>> otherInstanceCallback, string? uniqueName = null)
         {
+            if (otherInstanceCallback == null) throw new ArgumentNullException(nameof(otherInstanceCallback));
             var un = uniqueName ?? DefaultUniqueName;
             if (IsApplicationFirstInstance(un))
             {

--- a/SingleInstanceHelper/ApplicationActivator.cs
+++ b/SingleInstanceHelper/ApplicationActivator.cs
@@ -76,11 +76,17 @@ namespace SingleInstanceHelper
             Action<IReadOnlyList<string>> otherInstanceCallback)
         {
             var pipeName = GetPipeName(uniqueName);
+            var pipeFlags =
+#if NETSTANDARD
+                PipeOptions.Asynchronous;
+#else
+                PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly;
+#endif
             while (true)
             {
                 // Create pipe and start the async connection wait
                 using var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.In, 1,
-                    PipeTransmissionMode.Byte, PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+                    PipeTransmissionMode.Byte, pipeFlags);
 
                 // Async wait for connections
                 await pipeServer.WaitForConnectionAsync();

--- a/SingleInstanceHelper/ApplicationActivator.cs
+++ b/SingleInstanceHelper/ApplicationActivator.cs
@@ -45,7 +45,7 @@ namespace SingleInstanceHelper
             {
                 _syncContext = SynchronizationContext.Current;
                 // Setup Named Pipe listener
-                NamedPipeServerCreateServer();
+                CreateNamedPipeServer();
                 return true;
             }
             else
@@ -57,7 +57,7 @@ namespace SingleInstanceHelper
                 };
 
                 // Send the message
-                NamedPipeClientSendOptions(namedPipeXmlPayload);
+                SendOptionsToNamedPipe(namedPipeXmlPayload);
                 return false; // Signal to quit
             }
         }
@@ -87,17 +87,15 @@ namespace SingleInstanceHelper
         ///     Uses a named pipe to send the currently parsed options to an already running instance.
         /// </summary>
         /// <param name="namedPipePayload"></param>
-        private static void NamedPipeClientSendOptions(Payload namedPipePayload)
+        private static void SendOptionsToNamedPipe(Payload namedPipePayload)
         {
             try
             {
-                using (var namedPipeClientStream = new NamedPipeClientStream(".", GetPipeName(), PipeDirection.Out))
-                {
-                    namedPipeClientStream.Connect(3000); // Maximum wait 3 seconds
+                using var namedPipeClientStream = new NamedPipeClientStream(".", GetPipeName(), PipeDirection.Out);
+                namedPipeClientStream.Connect(3000); // Maximum wait 3 seconds
 
-                    var ser = new DataContractJsonSerializer(typeof(Payload));
-                    ser.WriteObject(namedPipeClientStream, namedPipePayload);
-                }
+                var ser = new DataContractJsonSerializer(typeof(Payload));
+                ser.WriteObject(namedPipeClientStream, namedPipePayload);
             }
             catch (Exception)
             {
@@ -108,7 +106,7 @@ namespace SingleInstanceHelper
         /// <summary>
         ///     Starts a new pipe server if one isn't already active.
         /// </summary>
-        private static void NamedPipeServerCreateServer()
+        private static void CreateNamedPipeServer()
         {
             // Create pipe and start the async connection wait
             _namedPipeServerStream = new NamedPipeServerStream(
@@ -164,7 +162,7 @@ namespace SingleInstanceHelper
             }
 
             // Create a new pipe for next connection
-            NamedPipeServerCreateServer();
+            CreateNamedPipeServer();
         }
 
         private static string GetRunningProcessHash()

--- a/SingleInstanceHelper/ApplicationActivator.cs
+++ b/SingleInstanceHelper/ApplicationActivator.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO.Pipes;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
-using System.Xml.Serialization;
 
 namespace SingleInstanceHelper
 {
@@ -32,7 +31,7 @@ namespace SingleInstanceHelper
 
         /// <summary>
         /// Determines if the application should continue launching or return because it's not the first instance.
-        /// When not the first instance, the command line args will be passed to the first one. 
+        /// When not the first instance, the command line args will be passed to the first one.
         /// </summary>
         /// <param name="otherInstanceCallback">Callback to execute on the first instance with command line args from subsequent launches.
         /// Will not run on the main thread, marshalling may be required.</param>
@@ -111,7 +110,6 @@ namespace SingleInstanceHelper
         /// </summary>
         private static void NamedPipeServerCreateServer()
         {
-            // 
             // Create pipe and start the async connection wait
             _namedPipeServerStream = new NamedPipeServerStream(
                 GetPipeName(),
@@ -171,12 +169,10 @@ namespace SingleInstanceHelper
 
         private static string GetRunningProcessHash()
         {
-            using (var hash = SHA256.Create())
-            {
-                var processPath = Process.GetCurrentProcess().MainModule.FileName;
-                var bytes = hash.ComputeHash(Encoding.UTF8.GetBytes(processPath));
-                return Convert.ToBase64String(bytes);
-            }
+            using var hash = SHA256.Create();
+            var processPath = Assembly.GetEntryAssembly()!.Location;
+            var bytes = hash.ComputeHash(Encoding.UTF8.GetBytes(processPath));
+            return Convert.ToBase64String(bytes);
         }
     }
 }

--- a/SingleInstanceHelper/NuGet.props
+++ b/SingleInstanceHelper/NuGet.props
@@ -12,6 +12,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>

--- a/SingleInstanceHelper/NuGet.props
+++ b/SingleInstanceHelper/NuGet.props
@@ -6,14 +6,15 @@
     <PackageTags>wpf;windows forms;single instance</PackageTags>
     <PackageProjectUrl>https://github.com/onovotny/SingleInstanceHelper</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/SingleInstanceHelper/NuGet.props
+++ b/SingleInstanceHelper/NuGet.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
-    <Authors>Oren Novotny</Authors>
-    <Copyright>Copyright (C) Oren Novotny</Copyright>
+    <Authors>Claire Novotny</Authors>
+    <Copyright>Copyright (C) Claire Novotny</Copyright>
     <Description>Helper for Single Instance Applications for Windows Forms and WPF</Description>
     <PackageTags>wpf;windows forms;single instance</PackageTags>
-    <PackageProjectUrl>https://github.com/onovotny/SingleInstanceHelper</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/novotnyllc/SingleInstanceHelper</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -18,6 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/SingleInstanceHelper/Payload.cs
+++ b/SingleInstanceHelper/Payload.cs
@@ -1,18 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Xml.Serialization;
+﻿using System.Collections.Generic;
 
 namespace SingleInstanceHelper
 {
-    [DataContract]
     internal class Payload
     {
         /// <summary>
         ///     A list of command line arguments.
         /// </summary>
-        [DataMember]
         public List<string> CommandLineArguments { get; set; } = new List<string>();
     }
 }

--- a/SingleInstanceHelper/SingleInstanceHelper.csproj
+++ b/SingleInstanceHelper/SingleInstanceHelper.csproj
@@ -1,11 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\THIRD-PARTY-NOTICES.TXT" PackagePath="" Pack="true" />
   </ItemGroup>
+  <Import Project="NuGet.props" />
 </Project>

--- a/SingleInstanceHelper/SingleInstanceHelper.csproj
+++ b/SingleInstanceHelper/SingleInstanceHelper.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SingleInstanceHelper/SingleInstanceHelper.csproj
+++ b/SingleInstanceHelper/SingleInstanceHelper.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\THIRD-PARTY-NOTICES.TXT" PackagePath="" Pack="true" />
-    <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Condition="'$(TargetFramework)' != 'netcoreapp3.1'" Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
   <Import Project="NuGet.props" />
 </Project>

--- a/SingleInstanceHelper/SingleInstanceHelper.csproj
+++ b/SingleInstanceHelper/SingleInstanceHelper.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <None Include="..\THIRD-PARTY-NOTICES.TXT" PackagePath="" Pack="true" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
   <Import Project="NuGet.props" />
 </Project>

--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -6,7 +6,7 @@ The attached notices are provided for information only.
 License notice for AutoIt Consulting inspired code
 --------------------------------
 
-https://github.com/AutoItConsulting/examples-csharp/tree/master/MutexSingleInstanceAndNamedPipe
+https://www.autoitconsulting.com/site/development/single-instance-winform-app-csharp-mutex-named-pipes/
 
 MIT License
 

--- a/WinFormsTestApp/Form1.Designer.cs
+++ b/WinFormsTestApp/Form1.Designer.cs
@@ -35,10 +35,11 @@
             // label1
             // 
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 28.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 28.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
             this.label1.Location = new System.Drawing.Point(0, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(800, 376);
+            this.label1.Size = new System.Drawing.Size(400, 196);
             this.label1.TabIndex = 1;
             this.label1.Text = "Hello .NET Core!";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -46,9 +47,10 @@
             // buttonExit
             // 
             this.buttonExit.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.buttonExit.Location = new System.Drawing.Point(0, 376);
+            this.buttonExit.Location = new System.Drawing.Point(0, 196);
+            this.buttonExit.Margin = new System.Windows.Forms.Padding(2);
             this.buttonExit.Name = "buttonExit";
-            this.buttonExit.Size = new System.Drawing.Size(800, 74);
+            this.buttonExit.Size = new System.Drawing.Size(400, 38);
             this.buttonExit.TabIndex = 1;
             this.buttonExit.Text = "E&xit";
             this.buttonExit.UseVisualStyleBackColor = true;
@@ -56,21 +58,21 @@
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(400, 234);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.buttonExit);
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "Form1";
             this.Text = "Form1";
             this.ResumeLayout(false);
-
         }
 
-        #endregion
-
-        private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button buttonExit;
+        private System.Windows.Forms.Label label1;
+
+        #endregion
     }
 }
 

--- a/WinFormsTestApp/Form1.cs
+++ b/WinFormsTestApp/Form1.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace WinFormsTestApp

--- a/WinFormsTestApp/Program.cs
+++ b/WinFormsTestApp/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -13,14 +12,17 @@ namespace WinFormsTestApp
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main(string[] args)
+        static async Task Main()
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            var first = ApplicationActivator.LaunchOrReturn(otherInstance => { MessageBox.Show("got data: " + otherInstance.Skip(1).FirstOrDefault()); }, args);
-            if(!first)
-                return; 
+            var first = await ApplicationActivator.LaunchOrReturnAsync(otherInstance =>
+            {
+                MessageBox.Show("got data: " + otherInstance.Skip(1).FirstOrDefault());
+            });
+            if (!first)
+                return;
             Application.Run(new Form1());
         }
     }

--- a/WinFormsTestApp/WinFormsTestApp.csproj
+++ b/WinFormsTestApp/WinFormsTestApp.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\SingleInstanceHelper\SingleInstanceHelper.csproj" />
   </ItemGroup>
-
 </Project>

--- a/WpfTestApp/App.xaml.cs
+++ b/WpfTestApp/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using SingleInstanceHelper;
 
 namespace WpfTestApp
@@ -14,15 +8,11 @@ namespace WpfTestApp
     /// </summary>
     public partial class App : Application
     {
-        protected override void OnStartup(StartupEventArgs e)
+        protected override async void OnStartup(StartupEventArgs e)
         {
-
-            var first = ApplicationActivator.LaunchOrReturn(otherInstance => { MessageBox.Show("got data"); }, e.Args);
-            if (!first)
-            {
-                Shutdown();
-            }
-
+            var first = await ApplicationActivator.LaunchOrReturnAsync(
+                otherInstance => { MessageBox.Show("got data"); });
+            if (!first) Shutdown();
 
             base.OnStartup(e);
         }

--- a/WpfTestApp/MainWindow.xaml.cs
+++ b/WpfTestApp/MainWindow.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace WpfTestApp
 {

--- a/WpfTestApp/WpfTestApp.csproj
+++ b/WpfTestApp/WpfTestApp.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\SingleInstanceHelper\SingleInstanceHelper.csproj" />
   </ItemGroup>
-
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,17 +7,13 @@ pr:
   - rel/*
 
 pool:
-  vmImage: vs2017-win2016
+  vmImage: windows-latest
 
-variables: 
+variables:
   BuildConfiguration: Release
 
 steps:
-- task: DotNetCoreInstaller@0
-  inputs:
-    version: '3.0.100-preview-009754'
-
-- task: DotNetCoreCLI@2  
+- task: DotNetCoreCLI@2
   inputs:
     command: custom
     custom: tool
@@ -25,7 +21,7 @@ steps:
   displayName: Install NBGV tool
 
 - script: nbgv cloud
-  displayName: Set Version
+  displayName: Set NBGV Version
 
 - task: DotNetCoreCLI@2
   inputs:
@@ -39,10 +35,10 @@ steps:
     command: pack
     packagesToPack: 'SingleInstanceHelper/*.csproj'
     configuration: $(BuildConfiguration)
-    packDirectory: $(Build.ArtifactStagingDirectory)\Artifacts    
+    packDirectory: $(Build.ArtifactStagingDirectory)\Artifacts
     verbosityPack: Minimal
-  displayName: Pack  
-    
+  displayName: Pack
+
 - task: PowerShell@2
   displayName: Authenticode Sign artifacts
   inputs:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.301",
+    "rollforward": "latestFeature"
+  }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "2.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N


### PR DESCRIPTION
This PR adds a new method called `ApplicationActivator.RunOrReturnAsync` which communicates through the named pipe asynchronously. The synchronous method was removed (a breaking change that necessiates a major version bump).

Moreover, the library uses the much faster `System.Text.Json` serializer, is ported to .NET Standard 2.0, and builds `.snupkg` files as well for NuGet. It is also refactored to eliminate global state (for example the process' unique name is now passed as a paramater in `RunOrReturnAsync`).